### PR TITLE
Add PDF export alongside processed DOCX files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 python-docx
 Pillow
+fpdf2


### PR DESCRIPTION
## Summary
- add lightweight DOCX-to-PDF conversion using python-docx and fpdf2
- bundle generated PDFs next to processed DOCX files in the download ZIP
- surface PDF conversion issues in the interface and document new dependency

## Testing
- python -m py_compile app_phase1_streamlit.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a211826a4832cb1ab42b16dbc4fe0)