### PR TITLE
Fix dataclass import typo

### DIFF
--- a/app_phase1_streamlit.py
+++ b/app_phase1_streamlit.py
@@ -5,7 +5,7 @@ import re
 import os
 import unicodedata
 import hashlib
-from dataclasses import datacl
+from dataclasses import dataclass
 from docx import Document
 from PIL import Image
 import xml.etree.ElementTree as ET


### PR DESCRIPTION
## Summary
- correct the dataclasses import in `app_phase1_streamlit.py` so the dataclass decorator is available

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a24665bc4832cb2371bb3d7e2f6b5)