### PR TITLE
Ensure white text on blue backgrounds

### DIFF
--- a/app_phase1_streamlit.py
+++ b/app_phase1_streamlit.py
@@ -1781,8 +1781,8 @@ st.markdown(
             --brand-panel: #0e1c31;
             --brand-card: rgba(255, 255, 255, 0.04);
             --brand-border: rgba(255, 255, 255, 0.08);
-            --brand-text: #e3ecf7;
-            --brand-subtle: #c7d4e5;
+            --brand-text: #ffffff;
+            --brand-subtle: #ffffff;
         }}
         body,
         .stApp,


### PR DESCRIPTION
## Summary
- set brand text and subtle color variables to white for better contrast on blue backgrounds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a2606bc74832cb2e78aae9b81d73c)