### PR TITLE
Ensure sidebar section headings use brand text color

### DIFF
--- a/app_phase1_streamlit.py
+++ b/app_phase1_streamlit.py
@@ -1879,6 +1879,15 @@ st.markdown(
             font-weight: 700;
             color: var(--brand-text);
         }}
+        [data-testid="stSidebar"] h1,
+        [data-testid="stSidebar"] h2,
+        [data-testid="stSidebar"] h3,
+        [data-testid="stSidebar"] h4,
+        [data-testid="stSidebar"] p,
+        [data-testid="stSidebar"] span,
+        [data-testid="stSidebar"] label {{
+            color: var(--brand-text);
+        }}
         [data-testid="stSidebar"] > div {{
             background: var(--brand-panel);
         }}


### PR DESCRIPTION
## Summary
- ensure sidebar headings and helper text use the brand text color for consistent contrast

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a269f9ee8832cba36d820c4396edf)