### PR TITLE
Handle bytearray output when generating PDFs

### DIFF
--- a/app_phase1_streamlit.py
+++ b/app_phase1_streamlit.py
@@ -1771,7 +1771,10 @@ def docx_bytes_to_pdf_bytes(docx_bytes: bytes) -> bytes:
                 pdf.multi_cell(0, line_height, txt=" | ".join(cells_text))
                 pdf.ln(1)
 
-    return pdf.output(dest="S").encode("latin-1")
+    pdf_data = pdf.output(dest="S")
+    if isinstance(pdf_data, str):
+        return pdf_data.encode("latin-1")
+    return bytes(pdf_data)
 
 # ───────────────────────── Interface Streamlit ─────────────────────
 PRIMARY_BLUE = "#1A6DD0"  # Bleu Diploma Santé


### PR DESCRIPTION
## Summary
- handle fpdf output returned as bytearray or string to avoid encode errors during PDF generation
- ensure DOCX-to-PDF conversion always returns bytes for downstream use

## Testing
- python -m py_compile app_phase1_streamlit.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a291feaec832c93b15fbe3b1a77ef)