### PR TITLE
Remove PDF generation support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 streamlit
-python-docx
 Pillow
-fpdf2


### PR DESCRIPTION
## Summary
- remove PDF generation and download logic from Streamlit workflow
- drop unused PDF conversion code and dependencies

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b0926a568832ca2c51de5811b7820)